### PR TITLE
Remove a link to garlicinsight.com

### DIFF
--- a/public/views/index.html
+++ b/public/views/index.html
@@ -67,7 +67,7 @@
           Caution: website is currently in development and may be unstable at times.
         </p>
         <p>
-          Donate GRLC: <a href="https://garlicinsight.com/address/GVE8M5E1hwHrL7D8yW8QkU16w1L8sXTLYS">GVE8M5E1hwHrL7D8yW8QkU16w1L8sXTLYS</a>
+          Donate GRLC: <a href="address/GVE8M5E1hwHrL7D8yW8QkU16w1L8sXTLYS">GVE8M5E1hwHrL7D8yW8QkU16w1L8sXTLYS</a>
         </p>
         <div id="powered" class="row">
           <div class="powered-text">


### PR DESCRIPTION
Removes a link that incorrectly points to garlicinsight.com which is now hosting spam